### PR TITLE
Add mutter property check rather only relying on XDG_SESSION_DESKTOP …

### DIFF
--- a/turn-off-monitors
+++ b/turn-off-monitors
@@ -17,7 +17,7 @@
 function turn-off-screen-in-wayland()
 {
     echo "Turning off monitors..."
-    if [[ $XDG_SESSION_DESKTOP == gnome* ]]; then
+    if [[ $XDG_SESSION_DESKTOP == gnome* || $MUTTER_PROPERTY_SUPPORTED ]]; then
         _trigger-monitors-off-in-gnome-wayland
 
         local interaction_event=$(wait_until_mouse_or_keyboard_event)
@@ -88,6 +88,13 @@ function wait_until_mouse_or_keyboard_event()
     done
 }
 ### END framework/wait_until_mouse_or_keyboard_event.sh
+
+# C
+if busctl --user get-property org.gnome.Mutter.DisplayConfig \
+    /org/gnome/Mutter/DisplayConfig org.gnome.Mutter.DisplayConfig \
+    PowerSaveMode &>/dev/null; then
+    MUTTER_PROPERTY_SUPPORTED=true
+fi
 
 if [ "$XDG_SESSION_TYPE" == "wayland" ]; then
     turn-off-screen-in-wayland


### PR DESCRIPTION
Add support to gnome-shell +v48 on Ubuntu 25.04 and probably others as well