### PR TITLE
Update turn-off-monitors for Ubuntu 26.04

### DIFF
--- a/turn-off-monitors
+++ b/turn-off-monitors
@@ -17,7 +17,7 @@
 function turn-off-screen-in-wayland()
 {
     echo "Turning off monitors..."
-    if [[ $XDG_SESSION_DESKTOP == gnome* ]]; then
+    if [[ $XDG_SESSION_DESKTOP == gnome* || $XDG_SESSION_DESKTOP == ubuntu* ]]; then
         _trigger-monitors-off-in-gnome-wayland
 
         local interaction_event=$(wait_until_mouse_or_keyboard_event)


### PR DESCRIPTION
In Ubuntu 26.04 Gnome : 
 XDG_SESSION_DESKTOP=ubuntu
